### PR TITLE
Substitute s with lnbp1_msg for clarity

### DIFF
--- a/lnpbp-0001.md
+++ b/lnpbp-0001.md
@@ -73,7 +73,7 @@ For a given message `msg` and original public key `P` the **commit procedure** i
 1. Construct a byte string `lnbp1_msg`, composed of the original message prefixed with a single SHA256 hash of `LNPBP1`
    string and a single SHA256 hash of protocol-specific tag:
    `lnbp1_msg = SHA256("LNPBP1") || SHA256(<protocol-specific-tag>) || msg`
-2. Compute HMAC-SHA256 of the `lnbp1_msg` and `P`, named **tweaking factor**: `f = HMAC_SHA256(s, P)`
+2. Compute HMAC-SHA256 of the `lnbp1_msg` and `P`, named **tweaking factor**: `f = HMAC_SHA256(lnbp1_msg, P)`
 3. Make sure that the tweaking factor is less than order `p` of Zp prime number set used in Secp256k1 curve; otherwise
    fail the protocol.
 3. Multiply the tweaking factor on Secp256k1 generator point `G`: `F = G * f` ignoring the possible overflow of the


### PR DESCRIPTION
The second point of the specification paragraph states:

"Compute HMAC-SHA256 of the lnbp1_msg and P, named tweaking factor: f = HMAC_SHA256(s, P)"

However `s` is not previously defined, as the message string is previously called `lnbp1_msg`. Therefore, this PR substitutes the parameter `s` in the equation with `lnbp1_msg` for improved clarity.