### PR TITLE
LNPBP-1 pubkey serialization spec

### DIFF
--- a/lnpbp-0001.md
+++ b/lnpbp-0001.md
@@ -374,7 +374,7 @@ pub fn commit(
         .map_err(|_| Error::SumInfiniteResult)?;
 
     let mut hmac_engine =
-        HmacEngine::<sha256::Hash>::new(&pubkey_sum.serialize());
+        HmacEngine::<sha256::Hash>::new(&pubkey_sum.serialize_uncompressed());
 
     hmac_engine.input(&LNPBP1_HASHED_TAG[..]);
     hmac_engine.input(&protocol_tag[..]);

--- a/lnpbp-0001.md
+++ b/lnpbp-0001.md
@@ -130,26 +130,27 @@ the **commit procedure** runs as follows:
 
 1. Reduce list `P*` to a set of unique public keys `P`, by removing all duplicate 
    public keys from the list.
-3. Compute sum `S` of all unique public keys in set `P`; fail the protocol if
+2. Compute sum `S` of all unique public keys in set `P`; fail the protocol if
    an overflow over elliptic curve generator point order happens during the 
    procedure.
 3. Construct a byte string `lnpbp1_msg`, composed of the original message
    prefixed with a single SHA256 hash of `LNPBP1` string and a single SHA256
    hash of the protocol-specific `tag`:  
    `lnpbp1_msg = SHA256("LNPBP1") || SHA256(tag) || msg`
-4. Compute HMAC-SHA256 of `lnbp1_msg` using the sum of public keys `S`. The 
+4. 
+5. Compute HMAC-SHA256 of `lnbp1_msg` using the sum of public keys `S`. The 
    resulting value is named **tweaking factor** `f`:  
    `f = HMAC-SHA256(lnpbp1_msg, S)`
-5. Make sure that the tweaking factor is less than the order `n` of a generator 
+6. Make sure that the tweaking factor is less than the order `n` of a generator 
    point of the used elliptic curve, such that no overflow can happen when it is 
    added to the original public key. If the order is exceeded, fail the protocol
    indicating the reason of failure.
-6. Multiply the tweaking factor `f` on the used elliptic curve generator point `G`:  
+7. Multiply the tweaking factor `f` on the used elliptic curve generator point `G`:  
    `F = G * f`
-7. Check that the result of 6 is not equal to the point-at-infinity; otherwise 
+8. Check that the result of 7 is not equal to the point-at-infinity; otherwise 
    fail the protocol, indicating the reason of failure, such that the protocol 
    may be run with another initial public key set `P'`.
-8. Add the two elliptic curve points: the original public key `Po` and the
+9. Add the two elliptic curve points: the original public key `Po` and the
    point `F`, derived from the tweaking-factor. This will result in a tweaked 
    public key `T`: `T = Po + F`. Check that the result is not equal to the 
    point-at-infinity of the elliptic curve or fail the protocol otherwise, 


### PR DESCRIPTION
As raised in https://github.com/LNP-BP/LNPBPs/issues/108, LNPBP-1 must explicitly specify the serialization format for the public key (aggregated public key `S`), which is passed into SHA256-HMAC to compute the tweaking factor.

TBD:
1. @dr-orlovsky suggested to use the uncompressed format. However, if we use `key.serialize_uncompressed()` from `rust-secp256k1`, this produces a 65 byte array - not 64 byte as assumed by @dr-orlovsky because of the `0x04` prefix to denote uncompressed format. 65 byte means HMAC-SHA256 internals first compute a hash (sha256) again. Is this an issue? Could this introduce another length extension attack vector? Do we need to prepend two 32 byte tags as we do elsewhere?
2. We could specify to omit the `0x04` prefix for public key serialization in LNPBP-1. But this would be "uncommon", it would be a derivation from the defacto standard for uncompressed public keys. Would that be an issue? Create confusion?
3. If we decide for option 2 (64 byte) uncompressed pub key, we either:
    - have to create a new implementation for pubkey serialization instead of using `rust-secp256k1`
    - or use `rust-secp256k1` `key.serialize_uncompressed()`, but strip the first byte afterwards, before pushing the value
       into HMAC-SHA256. The question is if `serialize_uncompressed()` can be considered "stable" in a sense that the
       format of the resulting value will never change and always stay like it is now?
4. If we switch away from the current 33 byte `rust-secp256k1` function `key.serialize()`, most (all) of the test vectors in `Appendix A` change and need to be re-computed and changed in the spec (ideally before merging). I'm not a RUST dev and have no dev environment setup ready to do this. @dr-orlovsky can you help?