### PR TITLE
Fix RGB wallet to RGB std about LNP/BP-0025 and LNP/BP-0020

### DIFF
--- a/lnpbp-0020.md
+++ b/lnpbp-0020.md
@@ -180,7 +180,7 @@ Include from
 
 ## Reference implementation
 
-<https://github.com/RGB-WG/rgb-wallet/blob/master/std/src/interface/rgb20.rs>
+<https://github.com/RGB-WG/rgb-std/blob/master/src/interface/rgb20.rs>
 
 
 ## Acknowledgements

--- a/lnpbp-0025.md
+++ b/lnpbp-0025.md
@@ -104,7 +104,7 @@ so compatibility with other standards do not apply.
 
 ## Reference implementation
 
-<https://github.com/RGB-WG/rgb-wallet/blob/master/std/src/interface/rgb25.rs>
+<https://github.com/RGB-WG/rgb-std/blob/master/src/interface/rgb25.rs>
 
 
 ## Acknowledgements


### PR DESCRIPTION
Reference implementation is following old repository, RGB wallet, which was renamed for RGB STD.