### PR TITLE
Fix reference implementation of LNP/BP-0021

### DIFF
--- a/lnpbp-0021.md
+++ b/lnpbp-0021.md
@@ -180,6 +180,7 @@ interface RGB21
 
 ## Reference implementation
 
+https://github.com/RGB-WG/rgb-std/blob/master/src/interface/rgb21.rs
 
 ## Acknowledgements
 


### PR DESCRIPTION
This Standard is missing reference implementation around RGB21